### PR TITLE
add gym path into PYTHONPATH to import gym

### DIFF
--- a/buy_signal_agent/verystrongjoe/create_pickle.py
+++ b/buy_signal_agent/verystrongjoe/create_pickle.py
@@ -12,6 +12,8 @@ import os
 import argparse
 parser = argparse.ArgumentParser()
 parser.add_argument("-training", "--training", help="turn on training mode", action="store_true")
+parser.add_argument("-import-gym", "--import-gym",help="import trading gym", action="store_true")
+
 args = parser.parse_args()
 
 os.environ["CUDA_VISIBLE_DEVICES"] = str(config.BSA_PARAMS['P_TRAINING_GPU'])
@@ -26,6 +28,11 @@ if args.training:
     training_mode = True
 else:
     training_mode = False
+
+if args.import_gym:
+    import sys
+    sys.path.insert(0, config.GYM['HOME'])
+
 
 if training_mode:
     _csv_dir = config.BSA_PARAMS['CSV_DIR_FOR_CREATING_PICKLE_TRAINING']

--- a/buy_signal_agent/verystrongjoe/evaulate.py
+++ b/buy_signal_agent/verystrongjoe/evaulate.py
@@ -8,7 +8,16 @@ import pickle
 import os
 import config
 from gym_core.ioutil import *  # file i/o to load stock csv files
+import argparse
 
+parser = argparse.ArgumentParser()
+parser.add_argument("-import-gym", "--import-gym",help="import trading gym", action="store_true")
+
+args = parser.parse_args()
+
+if args.import_gym:
+    import sys
+    sys.path.insert(0, config.GYM['HOME'])
 
 os.environ["CUDA_VISIBLE_DEVICES"] = str(config.BSA_PARAMS['P_TRAINING_GPU'])
 _len_observation = int(config.BSA_PARAMS['P_OBSERVATION_LEN'])

--- a/buy_signal_agent/verystrongjoe/train.py
+++ b/buy_signal_agent/verystrongjoe/train.py
@@ -10,6 +10,17 @@ from sklearn.model_selection import GridSearchCV
 import os
 import pickle
 import config
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-import-gym", "--import-gym",help="import trading gym", action="store_true")
+
+args = parser.parse_args()
+
+if args.import_gym:
+    import sys
+    sys.path.insert(0, config.GYM['HOME'])
+
 
 os.environ["CUDA_VISIBLE_DEVICES"] = str(config.BSA_PARAMS['P_TRAINING_GPU'])
 _len_observation = int(config.BSA_PARAMS['P_OBSERVATION_LEN'])


### PR DESCRIPTION
서버에서 gym path를 PYTHONPATH 에 추가
- 서버에서 agent실행시  gym의 API / 데이터를 활용할수 있게 
- command parameter에 반영 --import-gym or -import-gym
- 그래서 아래처럼 실행하면 config.py의 GYM의 HOME을 읽어서 import 
`
python create-pickle.py --import-gym 

`